### PR TITLE
MacOS native build fixes

### DIFF
--- a/Globals.h
+++ b/Globals.h
@@ -113,6 +113,8 @@ struct global_settings {
     // gfx
     int iWindowWidth{ 800 };
     int iWindowHeight{ 600 };
+    float fWindowXScale { 1.0f };
+    float fWindowYScale { 1.0f };
     float fDistanceFactor{ 1.f }; // baza do przeliczania odległości dla LoD
     float targetfps{ 0.0f };
     bool bFullScreen{ false };

--- a/application.cpp
+++ b/application.cpp
@@ -69,7 +69,9 @@ void focus_callback( GLFWwindow *window, int focus ) {
 void window_resize_callback( GLFWwindow *window, int w, int h ) {
     // NOTE: we have two variables which basically do the same thing as we don't have dynamic fullscreen toggle
     // TBD, TODO: merge them?
+#if GLFW_VERSION_MAJOR > 3 || (GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 3)
     glfwGetWindowContentScale(window, &Global.fWindowXScale, &Global.fWindowYScale);
+#endif
     Global.iWindowWidth = w;
 	Global.iWindowHeight = h;
     glViewport( 0, 0, w, h );

--- a/application.cpp
+++ b/application.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 This Source Code Form is subject to the
 terms of the Mozilla Public License, v.
 2.0. If a copy of the MPL was not
@@ -69,13 +69,14 @@ void focus_callback( GLFWwindow *window, int focus ) {
 void window_resize_callback( GLFWwindow *window, int w, int h ) {
     // NOTE: we have two variables which basically do the same thing as we don't have dynamic fullscreen toggle
     // TBD, TODO: merge them?
+    glfwGetWindowContentScale(window, &Global.fWindowXScale, &Global.fWindowYScale);
     Global.iWindowWidth = w;
 	Global.iWindowHeight = h;
     glViewport( 0, 0, w, h );
 }
 
 void cursor_pos_callback( GLFWwindow *window, double x, double y ) {
-    Application.on_cursor_pos( x, y );
+    Application.on_cursor_pos( x * Global.fWindowXScale, y * Global.fWindowXScale);
 }
 
 void mouse_button_callback( GLFWwindow* window, int button, int action, int mods )
@@ -483,7 +484,7 @@ eu07_application::set_cursor( int const Mode ) {
 void
 eu07_application::set_cursor_pos( double const Horizontal, double const Vertical ) {
 
-    glfwSetCursorPos( m_windows.front(), Horizontal, Vertical );
+    glfwSetCursorPos( m_windows.front(), Horizontal / Global.fWindowXScale, Vertical / Global.fWindowYScale);
 }
 
 glm::dvec2
@@ -493,6 +494,9 @@ eu07_application::get_cursor_pos() const {
     if( !m_windows.empty() ) {
         glfwGetCursorPos( m_windows.front(), &pos.x, &pos.y );
     }
+
+    pos.x *= Global.fWindowXScale;
+    pos.y *= Global.fWindowYScale;
     return pos;
 }
 
@@ -500,6 +504,9 @@ void
 eu07_application::get_cursor_pos( double &Horizontal, double &Vertical ) const {
 
     glfwGetCursorPos( m_windows.front(), &Horizontal, &Vertical );
+
+    Horizontal *= Global.fWindowXScale;
+    Vertical   *= Global.fWindowYScale;
 }
 
 /*

--- a/openglrenderer.cpp
+++ b/openglrenderer.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 This Source Code Form is subject to the
 terms of the Mozilla Public License, v.
 2.0. If a copy of the MPL was not
@@ -3996,6 +3996,8 @@ opengl_renderer::Update_Pick_Control() {
     // determine point to examine
     glm::dvec2 mousepos;
     glfwGetCursorPos( m_window, &mousepos.x, &mousepos.y );
+    mousepos.x *= Global.fWindowXScale;
+    mousepos.y *= Global.fWindowYScale;
     mousepos.y = Global.iWindowHeight - mousepos.y; // cursor coordinates are flipped compared to opengl
 
 #ifdef EU07_USE_PICKING_FRAMEBUFFER
@@ -4003,8 +4005,8 @@ opengl_renderer::Update_Pick_Control() {
     if( true == m_framebuffersupport ) {
 //        ::glReadBuffer( GL_COLOR_ATTACHMENT0_EXT );
         pickbufferpos = glm::ivec2{
-            mousepos.x * EU07_PICKBUFFERSIZE / std::max( 1, Global.iWindowWidth ),
-            mousepos.y * EU07_PICKBUFFERSIZE / std::max( 1, Global.iWindowHeight ) };
+            mousepos.x * EU07_PICKBUFFERSIZE / std::max( 1, Global.iWindowWidth),
+            mousepos.y * EU07_PICKBUFFERSIZE / std::max( 1, Global.iWindowHeight) };
     }
     else {
 //        ::glReadBuffer( GL_BACK );
@@ -4360,8 +4362,10 @@ opengl_renderer::Init_caps() {
     }
 #endif
 
+    char* extensions = (char*)glGetString( GL_EXTENSIONS );
+
     WriteLog( "Supported extensions: \n"
-        + std::string((char *)glGetString( GL_EXTENSIONS )) );
+        + std::string(extensions ? extensions : "") );
 
     WriteLog( std::string("render path: ") + ( Global.bUseVBO ? "VBO" : "Display lists" ) );
     if( GL_EXT_framebuffer_object ) {


### PR DESCRIPTION
Fixes mouse and python support on native MacOS builds. I only changed the legacy renderer as the default/full one causes kernel panic after a few seconds of operation and I can't even debug it.