### PR TITLE
Usprawnienia UART

### DIFF
--- a/application.h
+++ b/application.h
@@ -94,9 +94,6 @@ public:
         is_server() const;
     bool
         is_client() const;
-#ifdef WITH_UART
-    UartStatus uart_status;
-#endif
 
 private:
 // types

--- a/application.h
+++ b/application.h
@@ -13,6 +13,9 @@ http://mozilla.org/MPL/2.0/.
 #include "PyInt.h"
 #include "network/manager.h"
 #include "headtrack.h"
+#ifdef WITH_UART
+#include "uart.h"
+#endif
 
 class eu07_application {
     const int MAX_NETWORK_PER_FRAME = 1000;
@@ -91,6 +94,9 @@ public:
         is_server() const;
     bool
         is_client() const;
+#ifdef WITH_UART
+    UartStatus uart_status;
+#endif
 
 private:
 // types

--- a/drivermode.cpp
+++ b/drivermode.cpp
@@ -140,7 +140,7 @@ driver_mode::drivermode_input::command_fallback( user_command const Command ) co
     if( lookup == commandfallbacks.end() ) {
         return { user_command::none, user_command::none };
     }
-    
+
     return lookup->second;
 }
 
@@ -600,7 +600,7 @@ driver_mode::update_camera( double const Deltatime ) {
         // debug camera
         DebugCamera.Update();
     }
-                                               
+
     // reset window state, it'll be set again if applicable in a check below
     Global.CabWindowOpen = false;
 
@@ -801,7 +801,7 @@ driver_mode::OnKeyDown(int cKey) {
     switch (cKey) {
 
         case GLFW_KEY_F4: {
-            if( Global.shiftState ) { ExternalView(); } // with Shift, cycle through external views 
+            if( Global.shiftState ) { ExternalView(); } // with Shift, cycle through external views
             else                    { InOutKey(); } // without, step out of the cab or return to it
             break;
         }
@@ -826,7 +826,7 @@ driver_mode::OnKeyDown(int cKey) {
         }
         case GLFW_KEY_F6: {
             // przyspieszenie symulacji do testowania scenerii... uwaga na FPS!
-            if( DebugModeFlag ) { 
+            if( DebugModeFlag ) {
 
                 if( Global.ctrlState ) { Global.fTimeSpeed = ( Global.shiftState ? 60.0 : 20.0 ); }
 				else                   { Global.fTimeSpeed = ( Global.shiftState ? 5.0 : Global.default_timespeed ); }
@@ -883,7 +883,7 @@ driver_mode::DistantView( bool const Near ) {
         ( simulation::Train != nullptr ) ?
             simulation::Train->Dynamic() :
             pDynamicNearest ) };
-    
+
     if( vehicle == nullptr ) { return; }
 
     auto const cab =
@@ -1049,7 +1049,7 @@ driver_mode::CabView() {
     m_externalview = false;
 
     // likwidacja obrotów - patrzy horyzontalnie na południe
-    Camera.Reset(); 
+    Camera.Reset();
 
     // bind camera with the vehicle
     Camera.m_owner = train->Dynamic();

--- a/driveruilayer.cpp
+++ b/driveruilayer.cpp
@@ -40,9 +40,6 @@ driver_ui::driver_ui() {
 
     m_aidpanel.title = STR("Driving Aid");
 
-    m_scenariopanel.size_min = { 435, 50 };
-    m_scenariopanel.size_max = { Global.fb_size.x * 0.95f, Global.fb_size.y * 0.95 };
-
     m_scenariopanel.title = STR("Scenario");
     m_scenariopanel.size_min = { 435, 85 };
     m_scenariopanel.size_max = { Global.fb_size.x * 0.95f, Global.fb_size.y * 0.95 };

--- a/driveruilayer.cpp
+++ b/driveruilayer.cpp
@@ -40,6 +40,9 @@ driver_ui::driver_ui() {
 
     m_aidpanel.title = STR("Driving Aid");
 
+    m_scenariopanel.size_min = { 435, 50 };
+    m_scenariopanel.size_max = { Global.fb_size.x * 0.95f, Global.fb_size.y * 0.95 };
+
     m_scenariopanel.title = STR("Scenario");
     m_scenariopanel.size_min = { 435, 85 };
     m_scenariopanel.size_max = { Global.fb_size.x * 0.95f, Global.fb_size.y * 0.95 };
@@ -116,7 +119,7 @@ driver_ui::on_key( int const Key, int const Action ) {
     }
 
     switch (Key) {
-            
+
 	    case GLFW_KEY_TAB: {
 		    m_mappanel.is_open = !m_mappanel.is_open;
 
@@ -130,7 +133,7 @@ driver_ui::on_key( int const Key, int const Action ) {
                 ( m_aidpanel.is_expanded == false ) ? 1 :
                 2 );
             state = clamp_circular( ++state, 3 );
-            
+
             m_aidpanel.is_open = ( state > 0 );
             m_aidpanel.is_expanded = ( state > 1 );
 
@@ -144,7 +147,7 @@ driver_ui::on_key( int const Key, int const Action ) {
                 ( m_timetablepanel.is_expanded == false ) ? 1 :
                 2 );
             state = clamp_circular( ++state, 3 );
-            
+
             m_timetablepanel.is_open = ( state > 0 );
             m_timetablepanel.is_expanded = ( state > 1 );
 

--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -34,6 +34,10 @@ http://mozilla.org/MPL/2.0/.
 #define DRIVER_HINT_CONTENT
 #include "driverhints.h"
 
+#ifdef WITH_UART
+#include "uart.h"
+#endif
+
 void
 drivingaid_panel::update() {
 
@@ -548,7 +552,9 @@ debug_panel::update() {
 	m_powergridlines.clear();
 	m_cameralines.clear();
 	m_rendererlines.clear();
+#ifdef WITH_UART
     m_uartlines.clear();
+#endif
 
 	update_section_vehicle( m_vehiclelines );
 	update_section_engine( m_enginelines );
@@ -559,7 +565,9 @@ debug_panel::update() {
 	update_section_powergrid( m_powergridlines );
 	update_section_camera( m_cameralines );
 	update_section_renderer( m_rendererlines );
+#ifdef WITH_UART
     update_section_uart(m_uartlines);
+#endif
 }
 
 void
@@ -621,6 +629,7 @@ debug_panel::render() {
                     avlports[i] = (char *) Application.uart_status.available_ports[i].c_str();
                 }
                 ImGui::Combo("Port", &Application.uart_status.selected_port_index, avlports, ports_num);
+                ImGui::Combo("Baud", &Application.uart_status.selected_baud_index, uart_baudrates_list, uart_baudrates_list_num);
             }
             ImGui::Checkbox("Enabled", &Application.uart_status.enabled);
         }

--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -614,6 +614,14 @@ debug_panel::render() {
         render_section_settings();
 #ifdef WITH_UART
         if(true == render_section( "UART", m_uartlines)) {
+            int ports_num = Application.uart_status.available_ports.size();
+            if(ports_num > 0) {
+                char **avlports = new char*[ports_num];
+                for (int i=0; i < ports_num; i++) {
+                    avlports[i] = (char *) Application.uart_status.available_ports[i].c_str();
+                }
+                ImGui::ListBox("Port", &Application.uart_status.selected_port_index, avlports, ports_num);
+            }
             ImGui::Checkbox("Enabled", &Application.uart_status.enabled);
         }
 #endif
@@ -1230,24 +1238,26 @@ debug_panel::update_section_scantable( std::vector<text_line> &Output ) {
 #ifdef WITH_UART
 void
 debug_panel::update_section_uart( std::vector<text_line> &Output ) {
+    UartStatus *status = &Application.uart_status;
+
     Output.emplace_back(
-        ("Port: " + Application.uart_status.port_name).c_str(),
+        ("Port: " + status->port_name).c_str(),
         Global.UITextColor
     );
     Output.emplace_back(
-        ("Baud: " + std::to_string(Application.uart_status.baud)).c_str(),
+        ("Baud: " + std::to_string(status->baud)).c_str(),
         Global.UITextColor
     );
-    if(Application.uart_status.is_connected) {
-        std::string synctext = Application.uart_status.is_synced ? "SYNCED" : "NOT SYNCED";
+    if(status->is_connected) {
+        std::string synctext = status->is_synced ? "SYNCED" : "NOT SYNCED";
         Output.emplace_back(("CONNECTED, " + synctext).c_str(), Global.UITextColor);
     } else {
         Output.emplace_back("* NOT CONNECTED *", Global.UITextColor);
     }
     Output.emplace_back(
         (
-            "Packets sent: "+std::to_string(Application.uart_status.packets_sent)
-            +" Packets received: "+std::to_string(Application.uart_status.packets_received)
+            "Packets sent: "+std::to_string(status->packets_sent)
+            +" Packets received: "+std::to_string(status->packets_received)
         ).c_str(),
         Global.UITextColor
     );

--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -622,14 +622,14 @@ debug_panel::render() {
         render_section_settings();
 #ifdef WITH_UART
         if(true == render_section( "UART", m_uartlines)) {
-            int ports_num = Application.uart_status.available_ports.size();
+            int ports_num = UartStatus.available_ports.size();
             char **avlports = new char*[ports_num];
             for (int i=0; i < ports_num; i++) {
-                avlports[i] = (char *) Application.uart_status.available_ports[i].c_str();
+                avlports[i] = (char *) UartStatus.available_ports[i].c_str();
             }
-            ImGui::Combo("Port", &Application.uart_status.selected_port_index, avlports, ports_num);
-            ImGui::Combo("Baud", &Application.uart_status.selected_baud_index, uart_baudrates_list, uart_baudrates_list_num);
-            ImGui::Checkbox("Enabled", &Application.uart_status.enabled);
+            ImGui::Combo("Port", &UartStatus.selected_port_index, avlports, ports_num);
+            ImGui::Combo("Baud", &UartStatus.selected_baud_index, uart_baudrates_list, uart_baudrates_list_num);
+            ImGui::Checkbox("Enabled", &UartStatus.enabled);
         }
 #endif
         // toggles
@@ -640,13 +640,6 @@ debug_panel::render() {
     ImGui::End();
     ImGui::PopFont();
 }
-
-#ifdef WITH_UART
-bool
-debug_panel::render_section_uart() {
-    return true;
-};
-#endif
 
 bool
 debug_panel::render_section_scenario() {
@@ -1245,7 +1238,7 @@ debug_panel::update_section_scantable( std::vector<text_line> &Output ) {
 #ifdef WITH_UART
 void
 debug_panel::update_section_uart( std::vector<text_line> &Output ) {
-    UartStatus *status = &Application.uart_status;
+    uart_status *status = &UartStatus;
 
     Output.emplace_back(
         ("Port: " + status->port_name).c_str(),

--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -548,6 +548,7 @@ debug_panel::update() {
 	m_powergridlines.clear();
 	m_cameralines.clear();
 	m_rendererlines.clear();
+    m_uartlines.clear();
 
 	update_section_vehicle( m_vehiclelines );
 	update_section_engine( m_enginelines );
@@ -558,6 +559,7 @@ debug_panel::update() {
 	update_section_powergrid( m_powergridlines );
 	update_section_camera( m_cameralines );
 	update_section_renderer( m_rendererlines );
+    update_section_uart(m_uartlines);
 }
 
 void
@@ -610,6 +612,11 @@ debug_panel::render() {
         render_section( "Camera", m_cameralines );
         render_section( "Gfx Renderer", m_rendererlines );
         render_section_settings();
+#ifdef WITH_UART
+        if(true == render_section( "UART", m_uartlines)) {
+            //ImGui::Checkbox("Enabled", &Global.uart_conf.enable);
+        }
+#endif
         // toggles
         ImGui::Separator();
         ImGui::Checkbox( "Debug Mode", &DebugModeFlag );
@@ -618,6 +625,13 @@ debug_panel::render() {
     ImGui::End();
     ImGui::PopFont();
 }
+
+#ifdef WITH_UART
+bool
+debug_panel::render_section_uart() {
+    return true;
+};
+#endif
 
 bool
 debug_panel::render_section_scenario() {
@@ -1212,6 +1226,27 @@ debug_panel::update_section_scantable( std::vector<text_line> &Output ) {
 		Output.front().data = "(no points of interest)";
 	}
 }
+
+#ifdef WITH_UART
+void
+debug_panel::update_section_uart( std::vector<text_line> &Output ) {
+    Output.emplace_back(("Port: " + Global.uart_conf.port).c_str(), Global.UITextColor);
+    Output.emplace_back(("Baud: " + std::to_string(Global.uart_conf.baud)).c_str(), Global.UITextColor);
+    if(Application.uart_status.is_connected) {
+        std::string synctext = Application.uart_status.is_synced ? "SYNCED" : "NOT SYNCED";
+        Output.emplace_back(("CONNECTED, " + synctext).c_str(), Global.UITextColor);
+    } else {
+        Output.emplace_back("* NOT CONNECTED *", Global.UITextColor);
+    }
+    Output.emplace_back(
+        (
+            "Packets sent: "+std::to_string(Application.uart_status.packets_sent)
+            +" Packets received: "+std::to_string(Application.uart_status.packets_received)
+        ).c_str(),
+        Global.UITextColor
+    );
+}
+#endif
 
 void
 debug_panel::update_section_scenario( std::vector<text_line> &Output ) {

--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -620,7 +620,7 @@ debug_panel::render() {
                 for (int i=0; i < ports_num; i++) {
                     avlports[i] = (char *) Application.uart_status.available_ports[i].c_str();
                 }
-                ImGui::ListBox("Port", &Application.uart_status.selected_port_index, avlports, ports_num);
+                ImGui::Combo("Port", &Application.uart_status.selected_port_index, avlports, ports_num);
             }
             ImGui::Checkbox("Enabled", &Application.uart_status.enabled);
         }

--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -614,7 +614,7 @@ debug_panel::render() {
         render_section_settings();
 #ifdef WITH_UART
         if(true == render_section( "UART", m_uartlines)) {
-            //ImGui::Checkbox("Enabled", &Global.uart_conf.enable);
+            ImGui::Checkbox("Enabled", &Application.uart_status.enabled);
         }
 #endif
         // toggles
@@ -1230,8 +1230,14 @@ debug_panel::update_section_scantable( std::vector<text_line> &Output ) {
 #ifdef WITH_UART
 void
 debug_panel::update_section_uart( std::vector<text_line> &Output ) {
-    Output.emplace_back(("Port: " + Global.uart_conf.port).c_str(), Global.UITextColor);
-    Output.emplace_back(("Baud: " + std::to_string(Global.uart_conf.baud)).c_str(), Global.UITextColor);
+    Output.emplace_back(
+        ("Port: " + Application.uart_status.port_name).c_str(),
+        Global.UITextColor
+    );
+    Output.emplace_back(
+        ("Baud: " + std::to_string(Application.uart_status.baud)).c_str(),
+        Global.UITextColor
+    );
     if(Application.uart_status.is_connected) {
         std::string synctext = Application.uart_status.is_synced ? "SYNCED" : "NOT SYNCED";
         Output.emplace_back(("CONNECTED, " + synctext).c_str(), Global.UITextColor);

--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -623,14 +623,12 @@ debug_panel::render() {
 #ifdef WITH_UART
         if(true == render_section( "UART", m_uartlines)) {
             int ports_num = Application.uart_status.available_ports.size();
-            if(ports_num > 0) {
-                char **avlports = new char*[ports_num];
-                for (int i=0; i < ports_num; i++) {
-                    avlports[i] = (char *) Application.uart_status.available_ports[i].c_str();
-                }
-                ImGui::Combo("Port", &Application.uart_status.selected_port_index, avlports, ports_num);
-                ImGui::Combo("Baud", &Application.uart_status.selected_baud_index, uart_baudrates_list, uart_baudrates_list_num);
+            char **avlports = new char*[ports_num];
+            for (int i=0; i < ports_num; i++) {
+                avlports[i] = (char *) Application.uart_status.available_ports[i].c_str();
             }
+            ImGui::Combo("Port", &Application.uart_status.selected_port_index, avlports, ports_num);
+            ImGui::Combo("Baud", &Application.uart_status.selected_baud_index, uart_baudrates_list, uart_baudrates_list_num);
             ImGui::Checkbox("Enabled", &Application.uart_status.enabled);
         }
 #endif

--- a/driveruipanels.h
+++ b/driveruipanels.h
@@ -89,6 +89,9 @@ private:
     void update_section_powergrid( std::vector<text_line> &Output );
     void update_section_camera( std::vector<text_line> &Output );
     void update_section_renderer( std::vector<text_line> &Output );
+#ifdef WITH_UART
+    void update_section_uart( std::vector<text_line> &Output );
+#endif
     // section update helpers
     std::string update_vehicle_coupler( int const Side );
     std::string update_vehicle_brake() const;
@@ -97,6 +100,9 @@ private:
     bool render_section( std::vector<text_line> const &Lines );
     bool render_section_scenario();
     bool render_section_eventqueue();
+#ifdef WITH_UART
+    bool render_section_uart();
+#endif
     bool render_section_settings();
 // members
     std::array<char, 1024> m_buffer;
@@ -111,7 +117,13 @@ private:
         m_scenariolines,
         m_eventqueuelines,
         m_powergridlines,
+ #ifdef WITH_UART
+        m_rendererlines,
+        m_uartlines;
+ #else
         m_rendererlines;
+ #endif
+
 
 	double last_time = std::numeric_limits<double>::quiet_NaN();
 

--- a/driveruipanels.h
+++ b/driveruipanels.h
@@ -117,13 +117,8 @@ private:
         m_scenariolines,
         m_eventqueuelines,
         m_powergridlines,
- #ifdef WITH_UART
         m_rendererlines,
         m_uartlines;
- #else
-        m_rendererlines;
- #endif
-
 
 	double last_time = std::numeric_limits<double>::quiet_NaN();
 

--- a/uart.cpp
+++ b/uart.cpp
@@ -59,7 +59,7 @@ bool uart_input::setup_port()
         port = nullptr;
         return false;
     }
-    
+
     return true;
 }
 
@@ -173,17 +173,17 @@ void uart_input::poll()
 		return;
 
     sp_return ret;
-	
+
     if ((ret = sp_input_waiting(port)) >= 20)
     {
         std::array<uint8_t, 20> tmp_buffer; // TBD, TODO: replace with vector of configurable size?
         ret = sp_blocking_read(port, (void*)tmp_buffer.data(), tmp_buffer.size(), 0);
-		
+
         if (ret < 0) {
           setup_port();
           return;
         }
-		
+
 		bool sync;
 		if (tmp_buffer[0] != 0xEF || tmp_buffer[1] != 0xEF || tmp_buffer[2] != 0xEF || tmp_buffer[3] != 0xEF) {
 			if (conf.debug)
@@ -195,7 +195,7 @@ void uart_input::poll()
 				WriteLog("uart: sync ok");
 			sync = true;
 		}
-		
+
 		if (!sync) {
 			int sync_cnt = 0;
 			int sync_fail = 0;
@@ -231,7 +231,7 @@ void uart_input::poll()
       }
 			return;
 		}
-		
+
 		std::array<uint8_t, 16> buffer;
 		memmove(&buffer[0], &tmp_buffer[4], 16);
 

--- a/uart.h
+++ b/uart.h
@@ -84,7 +84,7 @@ private:
     using inputpin_sequence = std::vector<input_pin_t>;
 
     bool setup_port();
-    void enumerate_ports();
+    void find_ports();
 
 // members
     sp_port *port = nullptr;
@@ -93,7 +93,7 @@ private:
     std::array<std::uint8_t, 16> old_packet; // TBD, TODO: replace with vector of configurable size?
     std::chrono::time_point<std::chrono::high_resolution_clock> last_update;
     std::chrono::time_point<std::chrono::high_resolution_clock> last_setup;
-    std::chrono::time_point<std::chrono::high_resolution_clock> last_enumeration;
+    std::chrono::time_point<std::chrono::high_resolution_clock> last_port_find;
     conf_t conf;
 	bool data_pending = false;
     bool error_notified = false;

--- a/uart.h
+++ b/uart.h
@@ -15,6 +15,8 @@ class UartStatus {
         bool is_synced = false;
         unsigned long packets_sent = 0;
         unsigned long packets_received = 0;
+
+        void reset_stats();
 };
 
 class uart_input

--- a/uart.h
+++ b/uart.h
@@ -3,12 +3,17 @@
 #include <libserialport.h>
 #include "command.h"
 
+extern const char* uart_baudrates_list[];
+extern const size_t uart_baudrates_list_num;
+
 class UartStatus {
     public:
         std::string port_name = "";
         std::vector<std::string> available_ports = {};
         int selected_port_index = -1;
+        int selected_baud_index = -1;
         int active_port_index = -1;
+        int active_baud_index = -1;
         int baud = 0;
         bool enabled = false;
         bool is_connected = false;

--- a/uart.h
+++ b/uart.h
@@ -5,6 +5,9 @@
 
 class UartStatus {
     public:
+        std::string port_name = "";
+        int baud = 0;
+        bool enabled = false;
         bool is_connected = false;
         bool is_synced = false;
         unsigned long packets_sent = 0;

--- a/uart.h
+++ b/uart.h
@@ -64,7 +64,7 @@ private:
 
     using input_pin_t = std::tuple<std::size_t, input_type_t, user_command, user_command>;
     using inputpin_sequence = std::vector<input_pin_t>;
-    
+
     bool setup_port();
 
 // members
@@ -73,7 +73,9 @@ private:
     command_relay relay;
     std::array<std::uint8_t, 16> old_packet; // TBD, TODO: replace with vector of configurable size?
     std::chrono::time_point<std::chrono::high_resolution_clock> last_update;
+    std::chrono::time_point<std::chrono::high_resolution_clock> last_setup;
     conf_t conf;
 	bool data_pending = false;
+    bool error_notified = false;
     std::uint8_t m_trainstatecab { 0 }; // helper, keeps track of last active cab. 0: front cab, 1: rear cab
 };

--- a/uart.h
+++ b/uart.h
@@ -6,7 +6,7 @@
 extern const char* uart_baudrates_list[];
 extern const size_t uart_baudrates_list_num;
 
-class UartStatus {
+class uart_status {
     public:
         std::string port_name = "";
         std::vector<std::string> available_ports = {};
@@ -104,3 +104,5 @@ private:
     bool error_notified = false;
     std::uint8_t m_trainstatecab { 0 }; // helper, keeps track of last active cab. 0: front cab, 1: rear cab
 };
+
+extern uart_status UartStatus;

--- a/uart.h
+++ b/uart.h
@@ -3,6 +3,14 @@
 #include <libserialport.h>
 #include "command.h"
 
+class UartStatus {
+    public:
+        bool is_connected = false;
+        bool is_synced = false;
+        unsigned long packets_sent = 0;
+        unsigned long packets_received = 0;
+};
+
 class uart_input
 {
 public:
@@ -52,6 +60,8 @@ public:
         recall_bindings();
     void
         poll();
+    bool
+        is_connected();
 
 private:
 // types

--- a/uart.h
+++ b/uart.h
@@ -6,6 +6,9 @@
 class UartStatus {
     public:
         std::string port_name = "";
+        std::vector<std::string> available_ports = {};
+        int selected_port_index = -1;
+        int active_port_index = -1;
         int baud = 0;
         bool enabled = false;
         bool is_connected = false;
@@ -79,6 +82,7 @@ private:
     using inputpin_sequence = std::vector<input_pin_t>;
 
     bool setup_port();
+    void enumerate_ports();
 
 // members
     sp_port *port = nullptr;
@@ -87,6 +91,7 @@ private:
     std::array<std::uint8_t, 16> old_packet; // TBD, TODO: replace with vector of configurable size?
     std::chrono::time_point<std::chrono::high_resolution_clock> last_update;
     std::chrono::time_point<std::chrono::high_resolution_clock> last_setup;
+    std::chrono::time_point<std::chrono::high_resolution_clock> last_enumeration;
     conf_t conf;
 	bool data_pending = false;
     bool error_notified = false;


### PR DESCRIPTION
Dzień dobry, panie Milek7. Podsyłam propozycję usprawnień obsługi UART.

1. UI / Debug Panel: dodana sekcja UART z możliwością zmiany portu, baud rate, wstrzymania transmisji i z krótkim podsumowaniem stanu transmisji
2. Korekty obsługi UART, dzięki którym można podłączyć i odłączyć interfejs w trakcie działania symulatora.

Dzięki tym zmianom o wiele łatwiej prowadzić jest prace nad sprzętowymi pulpitami (można przełączać się między płytką prototypową, można zatrzymać transmisję i wgrać nowszy firmware bez wyłączania symulacji), oraz w razie przypadkowego rozłączenia komunikacji można bez problemu kontynuować jazdę bez pulpitu lub po jego ponownym połączeniu.

Uwagi:
- kompilację robiłem na linuxie, niestety nie miałem możliwości sprawdzić na Windowsie
- lista portów pobierana jest przez sp_list_ports() z libserialport. Na linuxie działa, na Windowsie nie miałem jak sprawdzić. EDIT: widzę automat CI - super!

![image](https://user-images.githubusercontent.com/139032/138983262-919fa773-28a8-47c9-a2ca-f05af3eac440.png)


PS. Odrębny PR przygotowany jest dla pana TMJ: https://github.com/tmj-fstate/maszyna/pull/20