### PR TITLE
add support for utf8 in data files

### DIFF
--- a/Event.cpp
+++ b/Event.cpp
@@ -720,7 +720,7 @@ putvalues_event::deserialize_( cParser &Input, scene::scratch_data &Scratchpad )
         if( contains( token, '#' ) ) {
             token.erase( token.find( '#' ) ); // obcięcie unikatowości
         }
-        win1250_to_ascii( token ); // get rid of non-ascii chars
+        remove_accents( token ); // get rid of non-ascii chars
         m_input.command_type = TCommandType::cm_PassengerStopPoint;
         // nie do kolejki (dla SetVelocity też, ale jak jest do toru dowiązany)
         m_passive = true;

--- a/Globals.cpp
+++ b/Globals.cpp
@@ -670,7 +670,11 @@ global_settings::ConfigParse(cParser &Parser) {
             Parser.getTokens(1, false);
             Parser >> asLang;
         }
-		else if( token == "python.updatetime" )
+        else if (token == "utf8") {
+            Parser.getTokens();
+            Parser >> enable_utf8;
+        }
+        else if( token == "python.updatetime" )
         {
             Parser.getTokens();
             Parser >> PythonScreenUpdateRate;
@@ -1324,6 +1328,7 @@ global_settings::export_as_text( std::ostream &Output ) const {
     export_as_text( Output, "hiddenevents", iHiddenEvents );
     export_as_text( Output, "pause", ( iPause & 1 ) != 0 );
     export_as_text( Output, "lang", asLang );
+    export_as_text( Output, "utf8", enable_utf8 );
     export_as_text( Output, "python.updatetime", PythonScreenUpdateRate );
     Output
         << "uitextcolor "

--- a/Globals.h
+++ b/Globals.h
@@ -318,6 +318,8 @@ struct global_settings {
     float m_skysaturationcorrection{ 1.65f };
     float m_skyhuecorrection{ 0.5f };
 
+    bool enable_utf8 = false;
+
 // methods
     void LoadIniFile( std::string asFileName );
     void ConfigParse( cParser &parser );

--- a/launcher/scenery_scanner.cpp
+++ b/launcher/scenery_scanner.cpp
@@ -54,9 +54,9 @@ void scenery_scanner::scan_scn(std::filesystem::path path)
 		if (line[3] == 'i')
 			desc.image_path = "scenery/images/" + line.substr(5);
 		else if (line[3] == 'n')
-			desc.name = win1250_to_utf8(line.substr(5));
+			desc.name = to_utf8(line.substr(5));
 		else if (line[3] == 'd')
-			desc.description += win1250_to_utf8(line.substr(5)) + '\n';
+			desc.description += to_utf8(line.substr(5)) + '\n';
 		else if (line[3] == 'f') {
 			std::string lang;
 			std::string file;
@@ -66,7 +66,7 @@ void scenery_scanner::scan_scn(std::filesystem::path path)
 			stream >> lang >> file;
 			std::getline(stream, label);
 
-			desc.links.push_back(std::make_pair(file, win1250_to_utf8(label)));
+			desc.links.push_back(std::make_pair(file, to_utf8(label)));
 		}
 		else if (line[3] == 'o') {
 			for (auto &trainset : desc.trainsets) {
@@ -74,7 +74,7 @@ void scenery_scanner::scan_scn(std::filesystem::path path)
 				        || line_counter > trainset.file_bounds.second)
 					continue;
 
-				trainset.description = win1250_to_utf8(line.substr(5));
+				trainset.description = to_utf8(line.substr(5));
 			}
 		}
 	}

--- a/launcher/textures_scanner.cpp
+++ b/launcher/textures_scanner.cpp
@@ -159,13 +159,13 @@ std::shared_ptr<ui::skin_meta> ui::vehicles_bank::parse_meta(const std::string &
 	std::getline(stream, meta->texture_author, ',');
 	std::getline(stream, meta->photo_author, ',');
 
-	meta->name = win1250_to_utf8(meta->name);
-	meta->short_id = win1250_to_utf8(meta->short_id);
-	meta->location = win1250_to_utf8(meta->location);
-	meta->rev_date = win1250_to_utf8(meta->rev_date);
-	meta->rev_company = win1250_to_utf8(meta->rev_company);
-	meta->texture_author = win1250_to_utf8(meta->texture_author);
-	meta->photo_author = win1250_to_utf8(meta->photo_author);
+	meta->name = to_utf8(meta->name);
+	meta->short_id = to_utf8(meta->short_id);
+	meta->location = to_utf8(meta->location);
+	meta->rev_date = to_utf8(meta->rev_date);
+	meta->rev_company = to_utf8(meta->rev_company);
+	meta->texture_author = to_utf8(meta->texture_author);
+	meta->photo_author = to_utf8(meta->photo_author);
 
 	meta->search_lowered +=
 	        ToLower("n:" + meta->name + ":i:" + meta->short_id + ":d:" + meta->location +

--- a/mtable.cpp
+++ b/mtable.cpp
@@ -351,7 +351,7 @@ bool TTrainParameters::LoadTTfile(std::string scnpath, int iPlus, double vmax)
                     } // while (!(() || fin.eof()));
                     if( s != "|" ) {
                         Relation1 = s;
-                        win1250_to_ascii( Relation1 );
+                        remove_accents( Relation1 );
                     }
                     else
                         ConversionError = -5;
@@ -367,7 +367,7 @@ bool TTrainParameters::LoadTTfile(std::string scnpath, int iPlus, double vmax)
                             break;
                     } // while (!( || (fin.eof())));
                     fin >> Relation2;
-                    win1250_to_ascii( Relation2 );
+                    remove_accents( Relation2 );
                     while (fin >> s || !fin.bad())
                     {
                         if (s == "Wymagany")
@@ -427,7 +427,7 @@ bool TTrainParameters::LoadTTfile(std::string scnpath, int iPlus, double vmax)
                                 fin >> s;
                             fin >> record->StationName;
                             // get rid of non-ascii chars. TODO: run correct version based on locale
-                            win1250_to_ascii( record->StationName ); 
+                            remove_accents( record->StationName ); 
                             do
                             {
                                 fin >> s;

--- a/openglrenderer.cpp
+++ b/openglrenderer.cpp
@@ -4278,7 +4278,7 @@ opengl_renderer::Update( double const Deltatime ) {
     auto const glerror = ::glGetError();
     if( glerror != GL_NO_ERROR ) {
         std::string glerrorstring;
-        win1250_to_ascii( glerrorstring );
+        remove_accents( glerrorstring );
         Global.LastGLError = std::to_string( glerror ) + " (" + glerrorstring + ")";
     }
 }

--- a/simulationstateserializer.cpp
+++ b/simulationstateserializer.cpp
@@ -188,7 +188,7 @@ state_serializer::deserialize_assignment( cParser &Input, scene::scratch_data &S
         && ( token != "endassignment" ) ) {
         // assignment is expected to come as string pairs: language id and the actual assignment enclosed in quotes to form a single token
         auto assignment{ Input.getToken<std::string>() };
-        win1250_to_ascii( assignment );
+        remove_accents( assignment );
         Scratchpad.trainset.assignment.emplace( token, assignment );
         token = Input.getToken<std::string>();
     }

--- a/uitranscripts.cpp
+++ b/uitranscripts.cpp
@@ -37,7 +37,7 @@ TTranscripts::Add( std::string const &txt, bool backgorund ) {
 
     if( true == txt.empty() ) { return; }
 
-    std::string asciitext{ txt }; win1250_to_ascii( asciitext ); // TODO: launch relevant conversion table based on language
+    std::string asciitext{ txt }; remove_accents( asciitext ); // TODO: launch relevant conversion table based on language
     cParser parser( asciitext );
     while( true == parser.getTokens( 3, false, "[]\n" ) ) {
 

--- a/utilities.h
+++ b/utilities.h
@@ -35,6 +35,22 @@ http://mozilla.org/MPL/2.0/.
 
 #define MAKE_ID4(a,b,c,d) (((std::uint32_t)(d)<<24)|((std::uint32_t)(c)<<16)|((std::uint32_t)(b)<<8)|(std::uint32_t)(a))
 
+const std::unordered_map<char, char> CP1250_ACCENTS_MAP {
+    { 165, 'A' }, { 198, 'C' }, { 202, 'E' }, { 163, 'L' }, { 209, 'N' }, { 211, 'O' }, { 140, 'S' }, { 143, 'Z' }, { 175, 'Z' },
+    { 185, 'a' }, { 230, 'c' }, { 234, 'e' }, { 179, 'l' }, { 241, 'n' }, { 243, 'o' }, { 156, 's' }, { 159, 'z' }, { 191, 'z' }
+};
+
+const std::unordered_map<std::string, char> UTF8_ACCENTS_MAP {
+    { u8"Ą", 'A' }, { u8"Ć", 'C' }, { u8"Ę", 'E'}, { u8"Ł", 'L' }, { u8"Ń", 'N' }, { u8"Ó", 'O' }, { u8"Ś", 'S' }, { u8"Ź", 'Z' }, { u8"Ż", 'Z' },
+    { u8"ą", 'a' }, { u8"ć", 'c' }, { u8"ę", 'e' }, { u8"ł", 'l' }, { u8"ń", 'n' }, { u8"ó", 'o' }, { u8"ś", 's' }, { u8"ź", 'z' }, { u8"ż", 'z' }
+};
+
+const std::unordered_map<char, std::string> CP1250_TO_UTF8_MAP {
+    { 165, u8"Ą" }, { 198, u8"Ć" }, { 202, u8"Ę" }, { 163, u8"Ł" }, { 209, u8"Ń" }, { 211, u8"Ó" }, { 140, u8"Ś" }, { 143, u8"Ź" }, { 175, u8"Ż" },
+    { 185, u8"ą" }, { 230, u8"ć" }, { 234, u8"ę" }, { 179, u8"ł" }, { 241, u8"ń" }, { 243, u8"ó" }, { 156, u8"ś" }, { 159, u8"ź" }, { 191, u8"ż" }
+};
+
+
 extern bool DebugModeFlag;
 extern bool FreeFlyModeFlag;
 extern bool EditorModeFlag;
@@ -153,11 +169,11 @@ std::string ToLower(std::string const &text);
 std::string ToUpper(std::string const &text);
 
 // replaces polish letters with basic ascii
-void win1250_to_ascii( std::string &Input );
-// TODO: unify with win1250_to_ascii()
+void remove_accents( std::string &Input );
+// TODO: unify with remove_accents()
 std::string Bezogonkow( std::string Input, bool const Underscorestospaces = false );
 
-std::string win1250_to_utf8(const std::string &input);
+std::string to_utf8(const std::string &input);
 
 inline
 std::string


### PR DESCRIPTION
This PR adds UTF8 support for data files (disabled by default). 
The UTF8 support can be enabled in `eu07.ini` file by adding `utf8 yes` line.