### PR TITLE
handle `none` arg in uartfeature + new syntax in debug

### DIFF
--- a/Globals.h
+++ b/Globals.h
@@ -200,6 +200,14 @@ struct global_settings {
     int iPoKeysPWM[ 7 ] = { 0, 1, 2, 3, 4, 5, 6 }; // numery wejść dla PWM
 #ifdef WITH_UART
     uart_input::conf_t uart_conf;
+    std::map<std::string, bool *> uartfeatures_map = {
+        {"main", &uart_conf.mainenable},
+        {"scnd", &uart_conf.scndenable},
+        {"train", &uart_conf.trainenable},
+        {"local", &uart_conf.localenable},
+        {"radiovolume", &uart_conf.radiovolumeenable},
+        {"radiochannel", &uart_conf.radiochannelenable}
+    };
 #endif
 #ifdef WITH_ZMQ
     std::string zmq_address;


### PR DESCRIPTION
I've found another edge case for a new syntax of `uartfeature`: there is no possibility to disable all uart features, because uartfeature requires 1 or 4 tokens. I've added handling of `none` keyword for such cases. Also I've changed config debug output to match new syntax and to display all supported features.