### PR TITLE
Add asio ref

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ref/asio"]
+	path = ref/asio
+	url = https://github.com/chriskohlhoff/asio.git


### PR DESCRIPTION
In order for cmake to run successfully, asio is needed in the `ref` folder. Without it, an error message is shown.

|`cmake` fail|`cmake` success|
|-|-|
|![fail](https://user-images.githubusercontent.com/123499/235439927-05ebcad8-80a4-4ff5-9cfb-eb59dc2f5c17.png)|![success](https://user-images.githubusercontent.com/123499/235439918-dfd10c08-e6d2-4e07-803f-f20aa3aa484f.png)|

This PR adds asio as a git submodule, pointing to the commit of the v1.28.0 release.