### PR TITLE
Limit camera pitch movement to +/- 90°

### DIFF
--- a/Camera.cpp
+++ b/Camera.cpp
@@ -167,13 +167,9 @@ void TCamera::Update()
         Angle.y += 2 * M_PI;
     }
 
-    Angle.x -= m_rotationoffsets.x * rotationfactor;
+    // Limit the camera pitch to +/- 90°.
+    Angle.x = clamp(Angle.x - (m_rotationoffsets.x * rotationfactor), -M_PI_2, M_PI_2);
     m_rotationoffsets.x *= ( 1.0 - rotationfactor );
-
-    if( m_owner != nullptr ) {
-        // jeżeli jazda z pojazdem ograniczenie kąta spoglądania w dół i w górę
-        Angle.x = clamp( Angle.x, -M_PI_4, M_PI_4 );
-    }
 
     // update position
     if( ( m_owner == nullptr )


### PR DESCRIPTION
The in-game camera has 2 issues:

1. The pitch movement in the cab is restricted to +/- 45°. This limits the player's ability to look down, for example at the switches to click on them.

2. The pitch movement in free fly mode is unrestricted, and the camera can be moved so that it will flip upside-down.

This PR fixes both issues by globally restricting the pitch movement to 90°, which matches how the camera behaves in other first-person games and train sims.

Before:

https://user-images.githubusercontent.com/123499/235447225-e450055d-3d80-4124-bffa-89bf8aae3c0d.mp4

After:

https://user-images.githubusercontent.com/123499/235446706-c451a016-ed78-48ad-990c-520b08cf7ac5.mp4|