### PR TITLE
Make right mouse down + scroll wheel adjust FOV instead of master controller

### DIFF
--- a/drivermouseinput.cpp
+++ b/drivermouseinput.cpp
@@ -281,8 +281,8 @@ drivermouse_input::move( double Mousex, double Mousey ) {
 void
 drivermouse_input::scroll( double const Xoffset, double const Yoffset ) {
 
-    if( Global.ctrlState ) {
-        // ctrl + scroll wheel adjusts fov
+    if( Global.ctrlState || m_buttons[1] == GLFW_PRESS ) {
+        // ctrl + scroll wheel or holding right mouse button + scroll wheel adjusts fov
 		Global.FieldOfView = clamp( static_cast<float>( Global.FieldOfView - Yoffset * 20.0 / Timer::subsystem.mainloop_total.average() ), 15.0f, 75.0f );
     }
     else {


### PR DESCRIPTION
By default, the mouse scroll wheel moves the master controller. To change FOV, the <kbd>Ctrl</kbd> key needs to be held down. This PR changes it so that in addition to the <kbd>Ctrl</kbd> key, if the right mouse button is held down while the scroll wheel is moved, it will change the FOV. This makes it significantly easier to zoom in on switches and gauges. When the right mouse button is not held down, the scroll wheel will still change the master controller.

Before:

https://user-images.githubusercontent.com/123499/235452837-adfdf362-9342-40d6-b083-4f0ace8b7960.mp4

After:

https://user-images.githubusercontent.com/123499/235452857-bc5275cd-008e-4112-8a43-b9cf286409b4.mp4