### PR TITLE
Fix tooltip delay by making it near-instantaneous

### DIFF
--- a/opengl33renderer.cpp
+++ b/opengl33renderer.cpp
@@ -4439,6 +4439,12 @@ void opengl33_renderer::Update(double const Deltatime)
 	Update_Pick_Control();
 	Update_Pick_Node();
 
+	if ((true == Global.ControlPicking) && (false == FreeFlyModeFlag))
+        Pick_Control_Callback([](const TSubModel *, const glm::vec2) {});
+	// temporary conditions for testing. eventually will be coupled with editor mode
+	if ((true == Global.ControlPicking) && (true == DebugModeFlag) && (true == FreeFlyModeFlag))
+        Pick_Node_Callback([](scene::basic_node *) {});
+
 	m_updateaccumulator += Deltatime;
 
 	if (m_updateaccumulator < 1.0)
@@ -4491,12 +4497,6 @@ void opengl33_renderer::Update(double const Deltatime)
 		m_geometry.update();
 		m_textures.update();
 	}
-
-	if ((true == Global.ControlPicking) && (false == FreeFlyModeFlag))
-        Pick_Control_Callback([](const TSubModel *, const glm::vec2) {});
-	// temporary conditions for testing. eventually will be coupled with editor mode
-	if ((true == Global.ControlPicking) && (true == DebugModeFlag) && (true == FreeFlyModeFlag))
-        Pick_Node_Callback([](scene::basic_node *) {});
 
 	// dump last opengl error, if any
     int glerror;

--- a/openglrenderer.cpp
+++ b/openglrenderer.cpp
@@ -4194,28 +4194,15 @@ opengl_renderer::Update( double const Deltatime ) {
 */
     m_updateaccumulator += Deltatime;
 
-    if( ( true  == Global.ControlPicking )
-     && ( false == FreeFlyModeFlag ) ) {
-        if( ( false == m_control_pick_requests.empty() )
-         || ( m_updateaccumulator >= 1.0 ) ) {
-            Update_Pick_Control();
-        }
-    }
-    else {
-        m_pickcontrolitem = nullptr;
+    if( ( true  == Global.ControlPicking ) && ( false == FreeFlyModeFlag ) ) {
+        Update_Pick_Control();
     }
     // temporary conditions for testing. eventually will be coupled with editor mode
     if( ( true == Global.ControlPicking )
      && ( true == FreeFlyModeFlag )
      && ( ( true == DebugModeFlag )
        || ( true == EditorModeFlag ) ) ) {
-        if( ( false == m_node_pick_requests.empty() )
-         || ( m_updateaccumulator >= 1.0 ) ) {
-            Update_Pick_Node();
-        }
-    }
-    else {
-        m_picksceneryitem = nullptr;
+        Update_Pick_Node();
     }
 
     if( m_updateaccumulator < 1.0 ) {


### PR DESCRIPTION
There is a 1-second delay before any tooltip actions are performed, whether it's showing a tooltip, hiding a tooltip, or updating a tooltip. This leads to the following issues:

1. It's difficult to tell if you've hovered over a clickable item unless you keep your mouse on it for a short time.

2. It's difficult to tell where the clickable area is because you have to pause your mouse movement and see if the tooltip goes away.

3. When moving quickly between different clickable items (like switches), the tooltip text is not updated immediately, making it look like a switch is actually another switch until the tooltip text updates.

This PR fixes these issues by removing the tooltip delay.

Before:

https://user-images.githubusercontent.com/123499/235454224-5f657d7d-38b7-43c6-b6c0-81b962563a0b.mp4

After:

https://user-images.githubusercontent.com/123499/235454241-bf91011a-9516-4a72-9941-37cff0e04ec5.mp4

