### PR TITLE
Make escape key close pause menu

### DIFF
--- a/driveruilayer.cpp
+++ b/driveruilayer.cpp
@@ -228,7 +228,9 @@ driver_ui::render_() {
 
 	ImGui::SetNextWindowSize(ImVec2(-1, -1));
 	if( ImGui::BeginPopupModal( popupheader, nullptr, 0 ) ) {
-		if( ImGui::Button( STR_C("Resume"), ImVec2( 150, 0 ) ) ) {
+		if( ( ImGui::Button( STR_C("Resume"), ImVec2( 150, 0 ) ) )
+		 || ( ImGui::IsKeyReleased( ImGui::GetKeyIndex( ImGuiKey_Escape ) ) ) )
+		{
 			m_relay.post(user_command::pausetoggle, 0.0, 0.0, GLFW_PRESS, 0);
         }
         if( ImGui::Button( STR_C("Quit"), ImVec2( 150, 0 ) ) ) {


### PR DESCRIPTION
When the Escape key is pressed, the game will pause and show a pause menu:

![pausepng](https://user-images.githubusercontent.com/123499/235457096-43d23ec0-edf6-45a5-a3a6-a654eb4e6219.png)

However, pressing the Escape key again will not dismiss the menu, and the "Resume" button must be clicked. This PR allows the menu to be dismissed by pressing the Escape key again.