### PR TITLE
Poprawka wysyłania danych przez UART

### DIFF
--- a/uart.cpp
+++ b/uart.cpp
@@ -599,7 +599,7 @@ void uart_input::poll()
 			//byte 21-22
 			SPLIT_INT16((time.wYear - 1) * 12 + time.wMonth - 1),
 			//byte 23-24
-			SPLIT_INT16((time.wDay - 1) * 1440 + time.wHour * 60 + time.wMinute),
+			SPLIT_INT16(time.wDay * 1440 + time.wHour * 60 + time.wMinute),
 			//byte 25-26
 			SPLIT_INT16(time.wSecond * 1000 + time.wMilliseconds),
 			//byte 27-30


### PR DESCRIPTION
Wydaje mi się że dzień w tym miejscu jest już w zakresie 0..30, więc nie ma potrzeby odejmowania jedynki - na arduino odbieram coś dziwnego w przypadku pierwszego dnia miesiąca i po analizie okazało się że jest to `(-1)*1440 + h*60 + m`
(nie sprawdzałem czy to rzeczywiście rozwiązuje problem bo miałem kłopoty z kompilacją, także proszę o weryfikację)